### PR TITLE
Add zoom offset option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The 'settings.py' file contains the following values:
 
     * MBTILES_TILE_EXT - The image extension to use (".png", ".jpg", ".jpeg")
 
+    * MBTILES_ZOOM_OFFSET - Apply a integer zoom offset, default '0'
+
     * USE_OSGEO_TMS_TILE_ADDRESSING - True (default) set to False to use Google XYZ addressing.
 
 ## Installation

--- a/settings.py
+++ b/settings.py
@@ -1,4 +1,5 @@
 MBTILES_ABSPATH = '/var/www/servembtiles/repo/mapdata/OSMBrightGray.mbtiles'
 MBTILES_TILE_EXT = '.png'  # VALID Extentions: (".png", ".jpg", ".jpeg")
+MBTILES_ZOOM_OFFSET = 0
 USE_OSGEO_TMS_TILE_ADDRESSING = True  # False will use google XYZ addressing
 


### PR DESCRIPTION
This allows an integer zoom offset to be applied. An example use case is
for EPSG:4326 projections where some tile sets have a single tile for zoom
level 0, versus 2x1 layout which libraries like Leaflet expect.